### PR TITLE
Bower now pointing to dist file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Zach Dunn <zach@onemightyroar.com>"
   ],
   "description": "A camera directive for Angular",
-  "main": "./src/directives/angular-camera.js",
+  "main": "dist/angular-camera.js",
   "keywords": [
     "webcam",
     "camera",


### PR DESCRIPTION
The main property of bower.json was pointing to a file that did not exist. It should instead be pointing to the distribution file.
