### PR TITLE
adjust callback invocation

### DIFF
--- a/src/directives/angular-camera.coffee
+++ b/src/directives/angular-camera.coffee
@@ -106,10 +106,10 @@ angular.module('omr.directives', [])
                 # Wait for overlay image to load before making dataURL
                 scope.$apply ->
                   scope.media = canvas.toDataURL('image/jpeg')
-                scope.captureCallback(scope.media) if scope.captureCallback?
+                scope.captureCallback({media: scope.media}) if scope.captureCallback?
             else
               scope.media = canvas.toDataURL('image/jpeg') # Assign to ngModel
-              scope.captureCallback(scope.media) if scope.captureCallback?
+              scope.captureCallback({media: scope.media}) if scope.captureCallback?
 
             scope.hideUI = false
           , countdownTime + 1000 # Add extra second for final message


### PR DESCRIPTION
Without this fix my app keeps taking: 

`TypeError: Cannot use 'in' operator to search for 'callback' in data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAMCAgICAgMCAgIDAwMD…Hw2diukZAycrj9c0g8LSbgVjOM8g4A/WvR10kH5fKG3rgCk/shWwxC7QciiU3Fe4TTqS+0f//Z
    at fn (eval at <anonymous> (http://localhost:3000/packages/angular_angular.js?c3a778493846e58a63e652cd68b47914889a794c:13177:15), <anonymous>:2:60)
    at Scope.$get.destination.(anonymous function) [as captureCallback] (http://localhost:3000/packages/angular_angular.js?c3a778493846e58a63e652cd68b47914889a794c:8775:22)
    at http://localhost:3000/client/lib/angular-camera.js?7c8c1e366f1e132b31f7ac471af2f570a387b206:90:27
    at http://localhost:3000/packages/angular_angular.js?c3a778493846e58a63e652cd68b47914889a794c:17741:31
    at completeOutstandingRequest (http://localhost:3000/packages/angular_angular.js?c3a778493846e58a63e652cd68b47914889a794c:5426:10)
    at http://localhost:3000/packages/angular_angular.js?c3a778493846e58a63e652cd68b47914889a794c:5698:7`

The fix syntax comes from http://stackoverflow.com/questions/24640284/angular-directive-callback
